### PR TITLE
Ensure the job wasn't grabbed by other workers more paranoiac.

### DIFF
--- a/lib/TheSchwartz.pm
+++ b/lib/TheSchwartz.pm
@@ -417,8 +417,16 @@ JOB:
             $server_time + ( $worker_class->grab_for || 1 ) );
 
         ## Update the job in the database, and end the transaction.
-        if ( $driver->update( $job, { grabbed_until => $old_grabbed_until } )
-            < 1 )
+        ## NOTE: For some reason, D::OD doesn't ensure the object's value is
+        ##       in bounds of original search query. so we need to be more paranoic
+        ##       to make sure it's not grabbed by other workers.
+        my $unixtime = $driver->dbd->sql_for_unixtime;
+        if ( $driver->update( $job, {
+            grabbed_until => [
+                '-and',
+                { op => '=', value => $old_grabbed_until},
+                \" <= $unixtime"
+            ]}) < 1 )
         {
             ## We lost the race to get this particular job--another worker must
             ## have got it and already updated it. Move on to the next job.

--- a/t/unique.t
+++ b/t/unique.t
@@ -27,15 +27,6 @@ run_tests(
         $handle = $client->insert($job);
         isa_ok $handle, 'TheSchwartz::JobHandle';
 
-        # insert again (notably to same db) and see it fails
-        $job = TheSchwartz::Job->new(
-            funcname => 'feed',
-            uniqkey  => "major",
-        );
-        ok( $job, "made another feed major job" );
-        $handle = $client->insert($job);
-        ok( !$handle, 'no handle' );
-
         # insert same uniqkey, but different func
         $job = TheSchwartz::Job->new(
             funcname => 'scratch',
@@ -44,6 +35,15 @@ run_tests(
         ok( $job, "made scratch major job" );
         $handle = $client->insert($job);
         isa_ok $handle, 'TheSchwartz::JobHandle';
+
+        # insert again (notably to same db) and see it fails
+        $job = TheSchwartz::Job->new(
+            funcname => 'feed',
+            uniqkey  => "major",
+        );
+        ok( $job, "made another feed major job" );
+        $handle = $client->insert($job);
+        ok( !$handle, 'no handle' );
 
     }
 );


### PR DESCRIPTION
Data::ObjectDriver doesn't ensure the object's value is in bounds of
original search query, beacuse to give a chance to pick the data from
cache layer. So we need to be more paranoic to make sure it's
not grabbed by other workers when to grab a job.

Without this fix, there are a small possibility that one job could be grabbed by two or more workers.
In our environment, we see this one job ran twice issue 5 or more times per year (and today I catch this).

Sorry for no test I don't have idea to reproduce this situation by code for now...