### PR TITLE
Replaces hard coded references to the Job class with calls to a class method

### DIFF
--- a/lib/TheSchwartz/JobHandle.pm
+++ b/lib/TheSchwartz/JobHandle.pm
@@ -7,7 +7,6 @@ use base qw( Class::Accessor::Fast );
 __PACKAGE__->mk_accessors(qw( dsn_hashed jobid client ));
 
 use TheSchwartz::ExitStatus;
-use TheSchwartz::Job;
 
 sub new_from_string {
     my $class = shift;

--- a/t/05-job-ctor.t
+++ b/t/05-job-ctor.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 19;
 
 use TheSchwartz;
+use TheSchwartz::Job;
 use Storable;
 
 # With this test, all data structures are in memory so far.  Nothing's


### PR DESCRIPTION
- The hard coded references to TheSchwartz::Job prevent sub-classing of
  the Job class. By changing them to method calls (which can be easily
  overridden in a sub-class of TheSchwartz) we can facilitate
  sub-classing of the TheSchwartz::Job.